### PR TITLE
Fixes / Improvements

### DIFF
--- a/overrides/config/veinmining-client.toml
+++ b/overrides/config/veinmining-client.toml
@@ -2,7 +2,7 @@
 ["vein mining"]
 	#Whether to activate vein mining (if using with the enchantment) by standing, crouching, or holding down the keybind
 	#Allowed Values: STANDING, CROUCHING, KEYBINDING
-	activationState = "STANDING"
+	activationState = "KEYBINDING"
 	#Whether to activate vein mining (if using without the enchantment) by standing, crouching, or holding down the keybind
 	#Allowed Values: STANDING, CROUCHING, KEYBINDING
 	activationStateWithoutEnchantment = "KEYBINDING"

--- a/overrides/kubejs/server_scripts/itemRightclicked.js
+++ b/overrides/kubejs/server_scripts/itemRightclicked.js
@@ -25,4 +25,10 @@ onEvent('block.right_click', event =>{
         data.Essences.Corruption = 0
         event.block.mergeEntityData(data) //why do i have to merge the entire data :/
     }
+	// Prevent Straw duping because it's annoying!
+	if (event.item == "createaddition:straw" && event.block.id == 'create:blaze_burner') {
+		if (!event.player.creativeMode) {
+			event.item.count--
+		}
+	}
 })


### PR DESCRIPTION
Fixed the vein mining config to default to KEYBINDING to avoid accidental vein mining since the default is STANDING

Also fixed the straw duping by force consuming straw when creating a liquid blaze burner.
Breaking the liquid burner drops the straw that was consumed.