### PR TITLE
Fix #2 for the Blaze Burner Straw duping issue

### DIFF
--- a/overrides/kubejs/server_scripts/integrated_dynamics.js
+++ b/overrides/kubejs/server_scripts/integrated_dynamics.js
@@ -1,0 +1,16 @@
+/**
+ * Simple recipe changes to reset IDs on parts.
+ */
+onEvent('recipes', event => {
+
+    // Fix Integrated Tunnels items not able to be reset once an ID is defined.
+    event.shapeless('integratedtunnels:part_interface_item', ['integratedtunnels:part_interface_item'])
+    event.shapeless('integratedtunnels:part_importer_item', ['integratedtunnels:part_importer_item'])
+    event.shapeless('integratedtunnels:part_exporter_item', ['integratedtunnels:part_exporter_item'])
+    event.shapeless('integratedtunnels:part_interface_fluid', ['integratedtunnels:part_interface_fluid'])
+    event.shapeless('integratedtunnels:part_importer_fluid', ['integratedtunnels:part_importer_fluid'])
+    event.shapeless('integratedtunnels:part_exporter_fluid', ['integratedtunnels:part_exporter_fluid'])
+
+    // Fix Integrated Dynamics items not able to be reset once an ID is defined.
+    event.shapeless('integrateddynamics:part_connector_mono_directional', ['integrateddynamics:part_connector_mono_directional'])
+})

--- a/overrides/kubejs/server_scripts/itemRightclicked.js
+++ b/overrides/kubejs/server_scripts/itemRightclicked.js
@@ -28,6 +28,7 @@ onEvent('block.right_click', event =>{
 	// Prevent Straw duping because it's annoying!
 	if (event.item == "createaddition:straw" && event.block.id == 'create:blaze_burner') {
 		if (!event.player.creativeMode) {
+			event.block.set('createaddition:liquid_blaze_burner')
 			event.item.count--
 		}
 	}


### PR DESCRIPTION
It's a bit of a hack still and should be fixed by the Create Additions mod but this will fix the straw duping issue and ensure the blaze burner is converted properly.