### PR TITLE
Add recipes and hide others for mods commonly talked about in Discord.

### DIFF
--- a/overrides/kubejs/client_scripts/jeiHideModsNotInPack.js
+++ b/overrides/kubejs/client_scripts/jeiHideModsNotInPack.js
@@ -1,0 +1,10 @@
+onEvent('jei.hide.items', event => {
+    event.hide('easy_villagers:auto_trader')
+    event.hide('easy_villagers:farmer')
+    event.hide('easy_villagers:iron_farm')
+    event.hide('easy_villagers:incubator')
+    event.hide('easy_villagers:villager')
+    event.hide(/enderchests\:*/)
+    event.hide(/enderstorage\:*/)
+    event.hide(/endertanks\:*/)
+})

--- a/overrides/kubejs/server_scripts/easy_villagers.js
+++ b/overrides/kubejs/server_scripts/easy_villagers.js
@@ -1,0 +1,43 @@
+onEvent('recipes', event => {
+    event.remove({output: 'easy_villagers:trader'})
+    event.remove({output: 'easy_villagers:auto_trader'})
+    event.remove({output: 'easy_villagers:farmer'})
+    event.remove({output: 'easy_villagers:breeder'})
+    event.remove({output: 'easy_villagers:converter'})
+    event.remove({output: 'easy_villagers:iron_farm'})
+    event.remove({output: 'easy_villagers:incubator'})
+
+    event.shaped('easy_villagers:trader', [
+        'PPP',
+        'PNP',
+        'CRC'
+    ], {
+        C: 'forbidden_arcanus:arcane_crystal_block',
+        P: 'forbidden_arcanus:dark_runic_glass_pane',
+        N: 'minecraft:netherite_ingot',
+        R: 'kubejs:runic_tablet'
+    })
+
+    event.shaped('easy_villagers:converter', [
+        'PPP',
+        'PZP',
+        'CRC'
+    ], {
+        C: 'forbidden_arcanus:arcane_crystal_block',
+        P: 'forbidden_arcanus:dark_runic_glass_pane',
+        Z: 'minecraft:zombie_head',
+        R: 'kubejs:runic_tablet'
+    })
+
+    event.shaped('easy_villagers:breeder', [
+        'PPP',
+        'PBP',
+        'CRC'
+    ], {
+        C: 'forbidden_arcanus:arcane_crystal_block',
+        P: 'forbidden_arcanus:dark_runic_glass_pane',
+        B: 'ars_nouveau:orange_sbed',
+        R: 'kubejs:runic_tablet'
+    })
+
+})

--- a/overrides/kubejs/server_scripts/ender_storage.js
+++ b/overrides/kubejs/server_scripts/ender_storage.js
@@ -1,0 +1,6 @@
+/* Remove Ender Storage, Ender Chests and Ender Tanks */
+onEvent('recipes', event => {
+    event.remove({mod: 'enderchests'})
+    event.remove({mod: 'enderstorage'})
+    event.remove({mod: 'endertanks'})
+})


### PR DESCRIPTION
Hide some Easy Villager items and make other recipes hard(er) Hide and remove all Ender Storage mod things, too cheaty!
This does NOT implement these mods, only adds recipes and hides others in the event someone decides to add to their pack.