### PR TITLE
Fix for Smithing Recipes

### DIFF
--- a/overrides/kubejs/server_scripts/compatRecipes.js
+++ b/overrides/kubejs/server_scripts/compatRecipes.js
@@ -583,18 +583,18 @@ onEvent('recipes', event => {
             if (remove_old) {
                 event.remove({output: entry[1]})
             };
-            event.smithing(entry[1], machine, entry[0])
+            event.smithing(entry[1], machine, Item.of(entry[0]).ignoreNBT())
             if(remove_old){
             event.recipes.createCompacting([machine,Item.of(entry[0]).withChance(0.4)],[entry[1],"kubejs:radiant_mechanism"])
             }
             if (!entry[1].toString().startsWith("x ",1) && !entry[1].toString().startsWith("x ", 2)){
                 if(Item.of(entry[1]).isBlock()){
-                event.recipes.create.itemApplication(entry[1],[machine,entry[0]])
+                event.recipes.create.itemApplication(entry[1],[machine,Item.of(entry[0]).ignoreNBT()])
                 } 
             }  
             if (entry[1].toString().startsWith("x ",1) || entry[1].toString().startsWith("x ", 2)){
                 
-                event.recipes.create.deploying(entry[1],[machine,entry[0]])
+                event.recipes.create.deploying(entry[1],[machine,Item.of(entry[0]).ignoreNBT()])
              
             }
             


### PR DESCRIPTION
Fix for Smithing Recipes
Allows for Eternal Warp Stones and Warp Stones with missing durability to still be used.

As currently configured, when you use a Warp Stone on a Time Machine to make a Waystone, the warp stone loses 1 durability.
The Warp Stone can no longer be used to make more Waystones.  Even an Eternal Warp Stone can't be used.
This fix will ignore the durability and NBT data of the deployment item to ensure the recipe works.