### PR TITLE
Fix some inconsistent arboreal extractor recipes by respecting thermal series

### DIFF
--- a/overrides/kubejs/server_scripts/treeExtractor.js
+++ b/overrides/kubejs/server_scripts/treeExtractor.js
@@ -93,7 +93,8 @@ let treeRegistry = [
                 trunk: 'byg:fir_log',
                 leaf: 'byg:fir_leaves',
                 sap: 'thermal:resin',
-                rate: { living: 25, dead: 4 }
+                // Respect bop's fir recipe in ThermalIntegration
+                rate: { living: 50, dead: 4 }
               },
               {
                 trunk: 'byg:green_enchanted_log',
@@ -188,8 +189,9 @@ let treeRegistry = [
               {
                 trunk: 'minecraft:spruce_log',
                 leaf: 'byg:blue_spruce_leaves',
-                sap: 'thermal:sap',
-                rate: { living: 25, dead: 4 }
+                sap: 'thermal:resin',
+                // Respect thermal's spruce recipe
+                rate: { living: 50, dead: 4 }
               },
               {
                 trunk: 'byg:pine_log',
@@ -249,7 +251,8 @@ let treeRegistry = [
                 trunk: 'minecraft:spruce_log',
                 leaf: 'byg:orange_spruce_leaves',
                 sap: 'thermal:resin',
-                rate: { living: 25, dead: 4 }
+                // Respect thermal's spruce recipe
+                rate: { living: 50, dead: 4 }
               },
               {
                 trunk: 'minecraft:oak_log',
@@ -267,7 +270,8 @@ let treeRegistry = [
                 trunk: 'minecraft:spruce_log',
                 leaf: 'byg:red_spruce_leaves',
                 sap: 'thermal:resin',
-                rate: { living: 25, dead: 4 }
+                // Respect thermal's spruce recipe
+                rate: { living: 50, dead: 4 }
               },
               {
                 trunk: 'architects_palette:twisted_log',
@@ -315,7 +319,8 @@ let treeRegistry = [
                 trunk: 'minecraft:spruce_log',
                 leaf: 'byg:yellow_spruce_leaves',
                 sap: 'thermal:resin',
-                rate: { living: 25, dead: 4 }
+                // Respect thermal's spruce recipe
+                rate: { living: 50, dead: 4 }
               },
               {
                 trunk: 'minecraft:birch_log',


### PR DESCRIPTION
There are some inconsistence experience about Arboreal Extractor recipes. JEI shows that Resin is produced from vanilla Spruce and the rate is 50mB per operation. However, Arboreal Extractor attached to vanilla spruce trees produces 25mB of Resin per operation.

Vanilla Spruce Extraction Screenshot: 

![Vanilla Spruce Extraction Screenshot](https://github.com/CoolerGangster/Create-Arcane-Engineering/assets/29692/843d7c19-9550-48d5-8b52-76755d4317c3)

This is because Arboreal Extractor looks up the output from the tree trunk block only. Here is the implemtation:

https://github.com/CoFH/ThermalCore/blob/b55443b053c0991a36fd36d3e192d8e825703f10/src/main/java/cofh/thermal/core/block/entity/device/DeviceTreeExtractorTile.java#L176

```java
renderFluid = TreeExtractorManager.instance().getFluid(level.getBlockState(trunkPos));
```

So, the recipe is overridden by KubeJS in this modpack.

BYG Spruce Extraction Screenshot:

![BYG Spruce Extraction Screenshot](https://github.com/CoolerGangster/Create-Arcane-Engineering/assets/29692/f5e179c1-5460-419e-8eda-a8c291f5d122)

By this implementation, modpack authors seems to be required to add the Arboreal Extractor recipe that is same output with the bundled recipes for existing trunk blocks.

This PR changes the rate of Resin production respecting the bundled recipes.

I'm sorry for my poor English. I hope this PR helps you.

