### PR TITLE
Adds recipes to convert Soul Sand to Soulless Sand and back using Create deployers

### DIFF
--- a/overrides/kubejs/server_scripts/deploying.js
+++ b/overrides/kubejs/server_scripts/deploying.js
@@ -1,5 +1,9 @@
 onEvent('recipes', event => {
     event.recipes.create.deploying('glassential:glass_ghostly', ['#forge:glass/colorless','quark:soul_bead'])
+
+    // Converting soul sand to soulless sand and back with Create deployers
+    event.recipes.create.deploying('minecraft:soul_sand', ['forbidden_arcanus:soulless_sand', 'forbidden_arcanus:soul'])
+    event.recipes.create.deploying(['forbidden_arcanus:soulless_sand', 'forbidden_arcanus:soul'], ['minecraft:soul_sand', 'forbidden_arcanus:soul_extractor']).keepHeldItem()
     
     event.recipes.create.deploying('ars_nouveau:magebloom_fiber', ['kubejs:mage_leaf', '#forge:tools/knives'])
     event.recipes.create.deploying('kubejs:runic_tablet', ['minecraft:smooth_stone_slab', 'forbidden_arcanus:rune'])


### PR DESCRIPTION
You can now use a conveyor with Create deployers to extract souls from soul sand, as well as to imbue soulless sand with souls.

This doesn't allow for any skips, because you still need to get the Soul Sand in the first place. But it does allow for a bit more flexibility in how you handle souls and soul sand at your factory. It also allows bulk processing of the soul sand mined from the Nether.