### PR TITLE
Makes PneumaticCraft electrostatic generators compatible with Immesive Weathering and Chipped

### DIFF
--- a/overrides/kubejs/server_scripts/lightning_rods.js
+++ b/overrides/kubejs/server_scripts/lightning_rods.js
@@ -1,0 +1,25 @@
+// Fixes variant iron bars added by Chipped and Immersive Weathering being incompatible with PneumaticCraft electrostatic compressors
+
+onEvent('tags.blocks', event => {
+	
+	// Immersive Weathering rusted and waxed iron bars
+	event.add('pneumaticcraft:electrostatic_grid', 'immersive_weathering:exposed_iron_bars')
+	event.add('pneumaticcraft:electrostatic_grid', 'immersive_weathering:weathered_iron_bars')
+	event.add('pneumaticcraft:electrostatic_grid', 'immersive_weathering:rusted_iron_bars')
+
+	event.add('pneumaticcraft:electrostatic_grid', 'immersive_weathering:waxed_iron_bars')
+	event.add('pneumaticcraft:electrostatic_grid', 'immersive_weathering:waxed_exposed_iron_bars')
+	event.add('pneumaticcraft:electrostatic_grid', 'immersive_weathering:waxed_weathered_iron_bars')
+	event.add('pneumaticcraft:electrostatic_grid', 'immersive_weathering:waxed_rusted_iron_bars')
+	
+	// Chipped iron bars variants
+	const stones = event.get('chipped:iron_bars').getObjectIds()
+	stones.forEach(i => {
+		event.add('pneumaticcraft:electrostatic_grid', i)
+	})
+	
+	// Immersive Engineering steel fences - used by IE's own lightning rods
+	// (this does nothing if IE is not installed)
+	event.add('pneumaticcraft:electrostatic_grid', 'immersiveengineering:steel_fence')
+
+})


### PR DESCRIPTION
Before, Immersive Weathering would rust the iron bars, and rusted iron bars were incompatible with PneumaticCraft electrostatic generators. Waxing the bars to protect them from rust didn't help - waxed bars were incompatible too. This made electrostatic generator lightning rod functionality almost impossible to use.

I adjusted the tags. Both rusted and waxed bars work with electrostatic generators now, and I added compatibility with all the Chipped iron bar variants too while at it.

Compatibility with steel fences from Immersive Engineering was added too, but there is no IE in vanilla CAE, so in most installs, that just does nothing.