### PR TITLE
Fix behavior parity issues between liquid blaze burners from C&A and regular blaze burners

### DIFF
--- a/overrides/kubejs/server_scripts/tags.js
+++ b/overrides/kubejs/server_scripts/tags.js
@@ -59,3 +59,10 @@ onEvent('tags.items', event => {
         "kubejs:portal_actuation_fluid_bucket"
     ])
 })
+
+onEvent('tags.blocks', event => {
+    event.add("create:fan_transparent", "createaddition:liquid_blaze_burner")
+    event.add("create:passive_boiler_heaters", "createaddition:liquid_blaze_burner")
+    event.add("create:fan_processing_catalysts/smoking", "createaddition:liquid_blaze_burner")
+    event.add("create:fan_processing_catalysts/blasting", "createaddition:liquid_blaze_burner")
+})


### PR DESCRIPTION
This fixes liquid blaze burners not passively heating steam boilers when unlit and not being considered valid heat sources by encased fans for bulk smoking/blasting.